### PR TITLE
Fix missing frontend serving

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const express = require('express');
 const bodyParser = require('body-parser');
 const i18n = require('i18n');
+const path = require('path');
 const app = express();
 
 // i18n configuration
@@ -14,6 +15,7 @@ i18n.configure({
 
 app.use(i18n.init);
 app.use(bodyParser.json());
+app.use(express.static(path.join(__dirname, '../frontend')));
 
 const productRoutes = require('./routes/products');
 const cartRoutes = require('./routes/cart');

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "main": "backend/index.js",
   "scripts": {
-
     "start": "node backend/index.js",
     "test": "node test/basic.test.js"
   },
@@ -14,19 +13,5 @@
     "express": "^4.18.2",
     "i18n": "^0.15.1",
     "jsonwebtoken": "^9.0.0"
-
-
-
-    "start": "node backend/index.js"
-  },
-  "dependencies": {
-    "express": "^4.18.2",
-    "body-parser": "^1.20.2",
-    "jsonwebtoken": "^9.0.0",
-    "i18n": "^0.15.1",
-    "bitcoinjs-lib": "^6.1.0"
-
-
-
   }
 }


### PR DESCRIPTION
## Summary
- serve frontend directory with Express

## Testing
- `npm test`
- `npm start` (fails if port already in use, but server runs when port free)

------
https://chatgpt.com/codex/tasks/task_e_6846db8ab9e88323b851d8adcb73d1cb